### PR TITLE
uncomment *unchecked-math* as it is needed in random ns

### DIFF
--- a/clojure/test/check/random.cljc
+++ b/clojure/test/check/random.cljc
@@ -76,7 +76,7 @@
         (bit-or -9223372036854775808))
     num))
 
-#_(set! *unchecked-math* :warn-on-boxed)
+(set! *unchecked-math* :warn-on-boxed)
 
 (defmacro ^:private bxoubsr
   "Performs (-> x (unsigned-bit-shift-right n) (bit-xor x))."


### PR DESCRIPTION
This line should not be commented.

## Note

A binding to `*unchecked-math*` is necessary at the upper level (for instance in a `nostrand` task).